### PR TITLE
Allow to set default break length in `.gtdrc`

### DIFF
--- a/gtd
+++ b/gtd
@@ -10,6 +10,7 @@ SPEAK_CMD="${SPEAK_CMD:-"&>/dev/null espeak"}"
 
 # Setting configuration
 DEFAULT_WORK_LENGTH=${DEFAULT_WORK_LENGTH:-15}
+DEFAULT_BREAK_LENGTH=$DEFAULT_BREAK_LENGTH
 NOTIFY_WORK="${NOTIFY_WORK:-"\"Get things done.\""}"
 NOTIFY_BREAK="${NOTIFY_BREAK:-"\"Take a break.\""}"
 SPEAK_WORK="${SPEAK_WORK:-"$NOTIFY_WORK"}"
@@ -89,7 +90,11 @@ fi
 
 # Set break length if specified and is a number
 if [[ -z "$2" ]]; then
-   break_length="$(( $work_length / 5 ))"
+   if [[ -z "$DEFAULT_BREAK_LENGTH" ]]; then
+      break_length="$(( $work_length / 5 ))"
+   else
+      break_length="$DEFAULT_BREAK_LENGTH"
+   fi
 elif [[ "$2" =~ [^0-9] ]]; then
    error "Break length must be a number of minutes."
 else

--- a/tests/config.test
+++ b/tests/config.test
@@ -2,21 +2,22 @@
 
 source "$MAIN"
 
-assert "$f CUSTOM_CMD:"          "$CUSTOM_CMD"          = "clear"
-assert "$f MPD_CMD:"             "$MPD_CMD"             = "mpc -q toggle"
-assert "$f NOTIFY_CMD:"          "$NOTIFY_CMD"          = "notify-send"
-assert "$f SPEAK_CMD:"           "$SPEAK_CMD"           = "&>/dev/null espeak"
-assert "$f DEFAULT_WORK_LENGTH:" "$DEFAULT_WORK_LENGTH" = "15"
-assert "$f NOTIFY_WORK:"         "$NOTIFY_WORK"         = "\"Get things done.\""
-assert "$f NOTIFY_BREAK:"        "$NOTIFY_BREAK"        = "\"Take a break.\""
-assert "$f SPEAK_WORK:"          "$SPEAK_WORK"          = "\"Get things done.\""
-assert "$f SPEAK_BREAK:"         "$SPEAK_BREAK"         = "\"Take a break.\""
-assert "$f DO_BREAK:"            "-z" "$DO_BREAK"
-assert "$f DO_CUSTOM:"           "-z" "$DO_CUSTOM"
-assert "$f DO_MPD:"              "-z" "$DO_MPD"
-assert "$f DO_NOTIFY:"           "-z" "$DO_NOTIFY"
-assert "$f DO_SPEAK:"            "-z" "$DO_SPEAK"
-assert "$f DO_TMUX:"             "-z" "$DO_TMUX"
+assert "$f CUSTOM_CMD:"           "$CUSTOM_CMD"           = "clear"
+assert "$f MPD_CMD:"              "$MPD_CMD"              = "mpc -q toggle"
+assert "$f NOTIFY_CMD:"           "$NOTIFY_CMD"           = "notify-send"
+assert "$f SPEAK_CMD:"            "$SPEAK_CMD"            = "&>/dev/null espeak"
+assert "$f DEFAULT_WORK_LENGTH:"  "$DEFAULT_WORK_LENGTH"  = "15"
+assert "$f DEFAULT_BREAK_LENGTH:" "$DEFAULT_BREAK_LENGTH" = ""
+assert "$f NOTIFY_WORK:"          "$NOTIFY_WORK"          = "\"Get things done.\""
+assert "$f NOTIFY_BREAK:"         "$NOTIFY_BREAK"         = "\"Take a break.\""
+assert "$f SPEAK_WORK:"           "$SPEAK_WORK"           = "\"Get things done.\""
+assert "$f SPEAK_BREAK:"          "$SPEAK_BREAK"          = "\"Take a break.\""
+assert "$f DO_BREAK:"             "-z" "$DO_BREAK"
+assert "$f DO_CUSTOM:"            "-z" "$DO_CUSTOM"
+assert "$f DO_MPD:"               "-z" "$DO_MPD"
+assert "$f DO_NOTIFY:"            "-z" "$DO_NOTIFY"
+assert "$f DO_SPEAK:"             "-z" "$DO_SPEAK"
+assert "$f DO_TMUX:"              "-z" "$DO_TMUX"
 
 # Configuration should allow overwrites {{{1
 
@@ -25,6 +26,7 @@ MPD_CMD=blah
 NOTIFY_CMD=blah
 SPEAK_CMD=blah
 DEFAULT_WORK_LENGTH=1
+DEFAULT_BREAK_LENGTH=1
 NOTIFY_WORK=blah
 NOTIFY_BREAK=blah
 SPEAK_WORK=blah
@@ -38,21 +40,22 @@ DO_TMUX=true
 
 source "$MAIN"
 
-assert "$f Overwrite CUSTOM_CMD:"          "$CUSTOM_CMD"          = "blah"
-assert "$f Overwrite MPD_CMD:"             "$MPD_CMD"             = "blah"
-assert "$f Overwrite NOTIFY_CMD:"          "$NOTIFY_CMD"          = "blah"
-assert "$f Overwrite SPEAK_CMD:"           "$SPEAK_CMD"           = "blah"
-assert "$f Overwrite DEFAULT_WORK_LENGTH:" "$DEFAULT_WORK_LENGTH" = "1"
-assert "$f Overwrite NOTIFY_WORK:"         "$NOTIFY_WORK"         = "blah"
-assert "$f Overwrite NOTIFY_BREAK:"        "$NOTIFY_BREAK"        = "blah"
-assert "$f Overwrite SPEAK_WORK:"          "$SPEAK_WORK"          = "blah"
-assert "$f Overwrite SPEAK_BREAK:"         "$SPEAK_BREAK"         = "blah"
-assert "$f Overwrite DO_BREAK:"            "$DO_BREAK"            = true
-assert "$f Overwrite DO_CUSTOM:"           "$DO_CUSTOM"           = true
-assert "$f Overwrite DO_MPD:"              "$DO_MPD"              = true
-assert "$f Overwrite DO_NOTIFY:"           "$DO_NOTIFY"           = true
-assert "$f Overwrite DO_SPEAK:"            "$DO_SPEAK"            = true
-assert "$f Overwrite DO_TMUX:"             "$DO_TMUX"             = true
+assert "$f Overwrite CUSTOM_CMD:"           "$CUSTOM_CMD"           = "blah"
+assert "$f Overwrite MPD_CMD:"              "$MPD_CMD"              = "blah"
+assert "$f Overwrite NOTIFY_CMD:"           "$NOTIFY_CMD"           = "blah"
+assert "$f Overwrite SPEAK_CMD:"            "$SPEAK_CMD"            = "blah"
+assert "$f Overwrite DEFAULT_WORK_LENGTH:"  "$DEFAULT_WORK_LENGTH"  = "1"
+assert "$f Overwrite DEFAULT_BREAK_LENGTH:" "$DEFAULT_BREAK_LENGTH" = "1"
+assert "$f Overwrite NOTIFY_WORK:"          "$NOTIFY_WORK"          = "blah"
+assert "$f Overwrite NOTIFY_BREAK:"         "$NOTIFY_BREAK"         = "blah"
+assert "$f Overwrite SPEAK_WORK:"           "$SPEAK_WORK"           = "blah"
+assert "$f Overwrite SPEAK_BREAK:"          "$SPEAK_BREAK"          = "blah"
+assert "$f Overwrite DO_BREAK:"             "$DO_BREAK"             = true
+assert "$f Overwrite DO_CUSTOM:"            "$DO_CUSTOM"            = true
+assert "$f Overwrite DO_MPD:"               "$DO_MPD"               = true
+assert "$f Overwrite DO_NOTIFY:"            "$DO_NOTIFY"            = true
+assert "$f Overwrite DO_SPEAK:"             "$DO_SPEAK"             = true
+assert "$f Overwrite DO_TMUX:"              "$DO_TMUX"              = true
 
 # Flags should toggle state {{{1
 


### PR DESCRIPTION
While `/ 5` is a perfectly sane default, I've found that I work best in 45/15 intervals. It's convenient to specify the default work duration in the config file, and I think I should be able to set the default break length there as well.