### PR TITLE
Fix restoring of ~/.gtdrc file in tests

### DIFF
--- a/tests/run
+++ b/tests/run
@@ -30,7 +30,7 @@ for file in "$(dirname $MAIN)/tests/"*.test; do
    DEBUG=true f="$(basename $file) =>" source "$file"
 done
 
-if [[ -e /tmp/old_gtdrc ]]; then
+if [[ -e /tmp/old_gtdrc || -h /tmp/old_gtdrc ]]; then
    mv /tmp/old_gtdrc ~/.gtdrc
 fi
 


### PR DESCRIPTION
Restoring would fail when ~/.gtdrc was a symbolic link